### PR TITLE
Log "Sent message" as debug, not info

### DIFF
--- a/src/main/java/com/zanox/vertx/mods/KinesisMessageProcessor.java
+++ b/src/main/java/com/zanox/vertx/mods/KinesisMessageProcessor.java
@@ -161,7 +161,7 @@ public class KinesisMessageProcessor extends BusModBase implements Handler<Messa
 			public void onSuccess(PutRecordRequest request, final PutRecordResult recordResult) {
 				ctx.runOnContext(new Handler<java.lang.Void>() {
 					public void handle(java.lang.Void v) {
-						logger.info("Sent message to Kinesis: " + recordResult.toString());
+						logger.debug("Sent message to Kinesis: " + recordResult.toString());
 						sendOK(event);
 					}
 				});


### PR DESCRIPTION
Log successfully sends at the debug level to avoid filling up logfiles.