### PR TITLE
Support optional endpoint config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ When deploying this module, you need to provide the following configuration:
     "streamName": <streamName>,
     "partitionKey": <partitionKey>,
     "region": <region>,
+    "endpoint": <endpoint>,
     "connectionTimeout": <connectionTimeout>,
     "maxConnection": <maxConnection>,
     "socketTimeout": <socketTimeout>,
@@ -56,6 +57,7 @@ The detailed description of each parameter:
 * `streamName` (mandatory) - The name of the Kinesis stream where the data will be put 
 * `partitionKey` (mandatory) - Determines which shard in the stream the data record is assigned to.
 * `region` (mandatory) - The regional endpoint for this client's service calls.
+* `endpoint` (optional) - A Kinesis endpoint, e.g., `http://localhost:4567`. Useful for testing against a service like [Kinesalite](https://github.com/mhart/kinesalite).
 * `connectionTimeout` (optional) - The amount of time to wait (in milliseconds) when initially establishing a connection before giving up and timing out. 
 * `maxConnection` (optional) - The maximum number of allowed open HTTP connections.
 * `socketTimeout` (optional) - The amount of time to wait (in milliseconds) for data to be transfered over an established, open connection before the connection times out and is closed.

--- a/src/main/java/com/zanox/vertx/mods/KinesisMessageProcessor.java
+++ b/src/main/java/com/zanox/vertx/mods/KinesisMessageProcessor.java
@@ -90,6 +90,7 @@ public class KinesisMessageProcessor extends BusModBase implements Handler<Messa
 		int socketTimeout = getOptionalIntConfig(SOCKET_TIMEOUT, ClientConfiguration.DEFAULT_SOCKET_TIMEOUT);
 		boolean useReaper = getOptionalBooleanConfig(USE_REAPER, ClientConfiguration.DEFAULT_USE_REAPER);
 		String userAgent = getOptionalStringConfig(USER_AGENT, ClientConfiguration.DEFAULT_USER_AGENT);
+		String endpoint = getOptionalStringConfig(ENDPOINT, null);
 
 
 		streamName = getMandatoryStringConfig(STREAM_NAME);
@@ -99,6 +100,9 @@ public class KinesisMessageProcessor extends BusModBase implements Handler<Messa
 		logger.info(" --- Stream name: " + streamName);
 		logger.info(" --- Partition key: " + partitionKey);
 		logger.info(" --- Region: " + region);
+		if(endpoint != null) {
+			logger.info(" --- Endpoint: " + endpoint);
+		}
 
 		ClientConfiguration clientConfiguration = new ClientConfiguration();
 		clientConfiguration.setConnectionTimeout(connectionTimeout);
@@ -122,6 +126,9 @@ public class KinesisMessageProcessor extends BusModBase implements Handler<Messa
 		AmazonKinesisAsyncClient kinesisAsyncClient = new AmazonKinesisAsyncClient(awsCredentialsProvider, clientConfiguration);
 		Region awsRegion = RegionUtils.getRegion(region);
 		kinesisAsyncClient.setRegion(awsRegion);
+		if(endpoint != null) {
+			kinesisAsyncClient.setEndpoint(endpoint);
+		}
 
 		return kinesisAsyncClient;
 	}

--- a/src/main/java/com/zanox/vertx/mods/internal/KinesisProperties.java
+++ b/src/main/java/com/zanox/vertx/mods/internal/KinesisProperties.java
@@ -27,6 +27,7 @@ public class KinesisProperties {
 	public static final String STREAM_NAME = "streamName";
 	public static final String PARTITION_KEY = "partitionKey";
 	public static final String REGION = "region";
+	public static final String ENDPOINT = "endpoint";
 	public static final String AWS_ACCESS_KEY = "awsAccessKey";
 	public static final String AWS_SECRET_KEY = "awsSecretKey";
 	private KinesisProperties() {


### PR DESCRIPTION
Allow the user to explicitly specify a Kinesis endpoint url. This is useful when testing against a service that implements the Kinesis interface, such as [Kinesalite](https://github.com/mhart/kinesalite).
